### PR TITLE
add forget password functionality

### DIFF
--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -14,9 +14,9 @@ return [
     */
 
     'reset' => 'Your password has been reset!',
-    'sent' => 'We have emailed your password reset link!',
+    'sent' => 'If this email exists, we will send you an email to reset your password',
     'throttled' => 'Please wait before retrying.',
     'token' => 'This password reset token is invalid.',
-    'user' => "We can't find a user with that email address.",
+    'user' => "If this email exist, we will send you an email to reset your password",
 
 ];

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,3 +1,6 @@
+@extends('common.master')
+<link href="{{ asset('css/tailwind.css') }}" rel="stylesheet">
+@section('content')
 <x-guest-layout>
     <x-auth-card>
         <x-slot name="logo">
@@ -34,3 +37,4 @@
         </form>
     </x-auth-card>
 </x-guest-layout>
+@endsection


### PR DESCRIPTION
created page with forget password.

email should be configured in the env file first as follow:
MAIL_MAILER=smtp
MAIL_HOST=smtp.gmail.com
MAIL_PORT=587
MAIL_USERNAME=test4laravel@gmail.com
MAIL_PASSWORD=sdxofzmrbfnjnkoc
MAIL_ENCRYPTION=tls
MAIL_FROM_ADDRESS=sdg@gmail.com
MAIL_FROM_NAME="SDG-Tool"